### PR TITLE
GitHub Workflows Debug Upload Coverage Report

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -32,10 +32,10 @@ jobs:
 
       - name: Run unit tests
         run: pytest test/ --cov=treescript_files --cov-report=html --cov-fail-under=85
-        continue-on-error: true
 
       - name: Upload Test Coverage Reports
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: treescript-files-${{ matrix.os }}-${{ matrix.python-version }}-coverage
           path: htmlcov/


### PR DESCRIPTION
Apply a correct method of ensuring coverage report artifacts are uploaded, specifically when coverage fails.

The `continue-on-error` will make the workflow pass when the step fails. This allows the upload artifact step to run, but the workflow should be marked as a failure when tests fail or coverage check fails.