### PR TITLE
Release 0.2.2

### DIFF
--- a/.changelists/sort.xml
+++ b/.changelists/sort.xml
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='utf-8'?>
+<sorting>
+    <changelist name="TreeScript Files Data Package" module="module">
+        <files first_dir="treescript_files" />
+        <files path_end="data" />
+        <files file_ext="py" />
+    </changelist>
+    <changelist name="TreeScript Files Input Package" module="module">
+        <files first_dir="treescript_files" />
+        <files path_end="input" />
+        <files file_ext="py" />
+    </changelist>
+    <changelist name="TreeScript Files Main Package" module="module">
+        <files first_dir="treescript_files" />
+        <files file_ext="py" />
+    </changelist>
+    <changelist name="Data Package Tests" module="module">
+        <files first_dir="test" />
+        <files path_end="data" />
+        <files file_ext="py" />
+    </changelist>
+    <changelist name="Input Package Tests" module="module">
+        <files first_dir="test" />
+        <files path_end="input" />
+        <files file_ext="py" />
+    </changelist>
+    <changelist name="Main Package Tests" module="module">
+        <files first_dir="test" />
+        <files path_end="treescript_files" />
+        <files file_ext="py" />
+    </changelist>
+    <changelist name="XML Package Tests" module="module">
+        <files first_dir="test" />
+        <files path_end="treescript_files/xml" />
+        <files file_ext="py" />
+    </changelist>
+    <changelist name="Test Fixtures and Data Providers" module="module">
+        <files first_dir="test" />
+        <files filename_prefix="conftest" />
+        <files file_ext="py" />
+    </changelist>
+    <changelist name="Changelists Config" module="hidden">
+        <files path_start=".changelists" />
+        <files filename_prefix="sort" />
+        <files file_ext="xml" />
+    </changelist>
+    <changelist name="GitHub Workflows" module="hidden">
+        <files path_start=".github/workflows" />
+        <files file_ext="yml" />
+    </changelist>
+    <changelist name="Documentation">
+        <files file_ext="md" />
+    </changelist>
+    <changelist name="Project Root">
+        <files first_dir="None" />
+    </changelist>
+</sorting>

--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -9,13 +9,16 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [ '3.10', '3.11', '3.12', '3.13.0-rc.1' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +31,8 @@ jobs:
       - name: Install Test Framework Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov
+          pip install -r requirements.txt
+          pip install pytest==8.3.5 pytest-cov==6.1.1
 
       - name: Run unit tests
         run: pytest test/ --cov=treescript_files --cov-report=html --cov-fail-under=85

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,7 +5,10 @@ name: Code Linting
 on:
   pull_request:
     branches: [main]
-  
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,13 +18,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: 'pip'
 
       - name: Install Linting Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff --no-deps
+          pip install ruff==0.12.4 --no-deps
 
       - name: Show Files To Be Linted
         run: ruff check --show-files

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/
 
       - name: Sign Distributions
-        uses: dk96-os/gh-action-sigstore-python@v3.1-dk96-os
+        uses: dk96-os/gh-action-sigstore-python@cf654f54962bafc7152d15da33e1015d8e913e2a # v3.2.7
         with:
           inputs: >-
             ./dist/*.tar.gz
@@ -52,6 +52,6 @@ jobs:
           cd ../
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           print-hash: true

--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,6 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
+.ftb/

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="treescript-files",
-    version="0.2.1",
+    version="0.2.2",
     description="Obtains the relative path of all files in the TreeScript.",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,15 +1,2 @@
-"""Initialize Test Module.
+""" Initialize Test Module.
 """
-
-
-def create_depth(depth: int) -> str:
-    """Creates a string of space chars equivalent to the given depth.
-
-	Parameters:
-	- depth (int): The amount of depth in the Tree Node Structure.
-
-	Returns:
-	str: The String of Space Char, of the required length.
-	"""
-	# Two space characters per unit of depth
-    return '  ' * depth

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,5 @@
 """ Test Fixtures and Data Providers.
 """
-import pytest
 
 
 def create_depth(depth: int) -> str:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,30 @@
+""" Test Fixtures and Data Providers.
+"""
+import pytest
+
+
+def raise_exception(name: str):
+    """ Raise an Exception in a mock method.
+ - Argument is lowercased before matching.
+
+**Available Exceptions:**
+ - OSError
+ - IOError
+ - SystemExit
+ - ValueError
+ - TypeError
+ - BaseException
+    """
+    match name.lower():
+        case 'oserror':
+            raise OSError
+        case 'ioerror':
+            raise IOError
+        case 'systemexit':
+            raise SystemExit
+        case 'valueerror':
+            raise ValueError
+        case 'typeerror':
+            raise TypeError
+        case 'baseexception':
+            raise BaseException

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,19 @@
 import pytest
 
 
+def create_depth(depth: int) -> str:
+    """ Creates a string of space chars equivalent to the given depth.
+
+**Parameters:**
+ - depth (int): The amount of depth in the Tree Node Structure.
+
+**Returns:**
+ str - The String of Space Char, of the required length.
+	"""
+    # Two space characters per unit of depth
+    return '  ' * depth
+
+
 def raise_exception(name: str):
     """ Raise an Exception in a mock method.
  - Argument is lowercased before matching.

--- a/test/test_argument_parser.py
+++ b/test/test_argument_parser.py
@@ -1,4 +1,4 @@
-"""Testing Argument Parser Module Methods.
+""" Testing Argument Parser Module Methods.
 """
 import pytest
 
@@ -46,11 +46,8 @@ def test_parse_arguments_output_separator_options(test_input,expect):
     ]
 )
 def test_parse_arguments_parent_path_missing_flag_raises_exit(test_input):
-    try:
+    with pytest.raises(SystemExit):
         parse_arguments(test_input)
-        assert False
-    except SystemExit:
-        assert True
 
 
 @pytest.mark.parametrize(
@@ -63,11 +60,8 @@ def test_parse_arguments_parent_path_missing_flag_raises_exit(test_input):
     ]
 )
 def test_parse_arguments_no_tree_raises_exit(test_input):
-    try:
+    with pytest.raises(SystemExit):
         parse_arguments(test_input)
-        assert False
-    except SystemExit:
-        assert True
 
 
 @pytest.mark.parametrize(
@@ -79,24 +73,15 @@ def test_parse_arguments_no_tree_raises_exit(test_input):
     ]
 )
 def test_parse_arguments_invalid_args_raises_exit(test_input):
-    try:
+    with pytest.raises(SystemExit):
         parse_arguments(test_input)
-        assert False
-    except SystemExit:
-        assert True
 
 
 def test_validate_arguments_empty_tree_file_name_raises_type_error():
-    try:
+    with pytest.raises(TypeError):
         _validate_arguments('', None)
-        assert False
-    except TypeError:
-        assert True
 
 
 def test_validate_arguments_empty_parent_path_raises_type_error():
-    try:
+    with pytest.raises(TypeError):
         _validate_arguments('tree', '')
-        assert False
-    except TypeError:
-        assert True

--- a/test/test_file_validation.py
+++ b/test/test_file_validation.py
@@ -1,0 +1,66 @@
+""" Testing File Validation Methods.
+"""
+import pytest
+from pathlib import Path
+
+from test.conftest import raise_exception
+from treescript_files.file_validation import validate_input_file
+
+
+@pytest.mark.parametrize(
+    "test_input,expect",
+    [
+        ("file_name", "file_data"),
+        ("file_name12", "file_data"),
+    ]
+)
+def test_validate_input_file_returns_data(test_input, expect):
+    with pytest.MonkeyPatch().context() as c:
+        c.setattr(Path, 'exists', lambda _: True)
+        c.setattr(Path, 'read_text', lambda _: "file_data")
+        assert validate_input_file(test_input) == expect
+
+
+def test_validate_input_file_does_not_exist_raises_exit():
+    with pytest.MonkeyPatch().context() as c:
+        c.setattr(Path, 'exists', lambda _: False)
+        with pytest.raises(SystemExit):
+            validate_input_file("file_name")
+
+
+def test_validate_input_file_is_empty_raises_exit():
+    with pytest.MonkeyPatch().context() as c:
+        c.setattr(Path, 'exists', lambda _: True)
+        c.setattr(Path, 'read_text', lambda _: "")
+        with pytest.raises(SystemExit):
+            validate_input_file("file_name")
+
+
+def test_validate_input_file_fails_to_read_raises_exit():
+    with pytest.MonkeyPatch().context() as c:
+        c.setattr(Path, 'exists', lambda _: True)
+        c.setattr(Path, 'read_text', lambda _: raise_exception('ioerror'))
+        with pytest.raises(SystemExit):
+            validate_input_file("file_name")
+
+
+def test_validate_input_file_os_error_raises_exit():
+    with pytest.MonkeyPatch().context() as c:
+        c.setattr(Path, 'exists', lambda _: True)
+        c.setattr(Path, 'read_text', lambda _: raise_exception('oserror'))
+        with pytest.raises(SystemExit, match='Failed to Read from File.'):
+            validate_input_file("file_name")
+
+
+@pytest.mark.parametrize(
+    "test_input,expect",
+    [
+        ("file_name", "file_data"),
+        ("file_name12", "file_data"),
+    ]
+)
+def test_validate_input_file_is_empty_returns_none(test_input, expect):
+    with pytest.MonkeyPatch().context() as c:
+        c.setattr(Path, 'exists', lambda _: True)
+        c.setattr(Path, 'read_text', lambda _: expect)
+        assert validate_input_file(test_input) == expect

--- a/test/test_line_reader.py
+++ b/test/test_line_reader.py
@@ -1,10 +1,10 @@
-"""Testing Line Reader Methods.
+""" Testing Line Reader Methods.
 """
 import pytest
 
+from test.conftest import create_depth
 from treescript_files.line_reader import _calculate_depth, _process_line, _validate_node_name, read_input_tree
 from treescript_files.tree_data import TreeData
-from test import create_depth
 
 
 # Directory Variants: A tuple of all possible ways that a directory may be represented.
@@ -76,11 +76,8 @@ def test_process_line_file_returns_data(test_input, expect):
     ]
 )
 def test_process_line_file_odd_spaces_raises_exit(test_input):
-    try:
+    with pytest.raises(SystemExit):
         _process_line(1, test_input)
-        assert False
-    except SystemExit:
-        assert True
 
 
 @pytest.mark.parametrize(
@@ -126,11 +123,8 @@ def test_process_line_dir_returns_data(test_input, expect):
     ]
 )
 def test_process_line_dir_odd_spaces_raises_exit(test_input):
-    try:
+    with pytest.raises(SystemExit):
         _process_line(1, test_input)
-        assert False
-    except SystemExit:
-        assert True
 
 
 @pytest.mark.parametrize(
@@ -143,12 +137,8 @@ def test_process_line_dir_odd_spaces_raises_exit(test_input):
     ]
 )
 def test_process_line_parent_dir_raise_exit(test_input):
-    try:
+    with pytest.raises(SystemExit):
         _process_line(1, test_input)
-        raised_exit = False
-    except SystemExit:
-        raised_exit = True
-    assert raised_exit
 
 
 @pytest.mark.parametrize(
@@ -161,12 +151,8 @@ def test_process_line_parent_dir_raise_exit(test_input):
     ]
 )
 def test_process_line_current_dir_raise_exit(test_input):
-    try:
+    with pytest.raises(SystemExit):
         _process_line(1, test_input)
-        raised_exit = False
-    except SystemExit:
-        raised_exit = True
-    assert raised_exit
 
 
 @pytest.mark.parametrize(
@@ -258,11 +244,8 @@ def test_read_input_tree_files_including_comment_yields_data():
     assert next(generator) == TreeData(1, 0, True, 'src', '')
     assert next(generator) == TreeData(2, 1, False, 'data.txt', '')
     assert next(generator) == TreeData(4, 1, False, 'more_data.txt', 'Label')
-    try:
+    with pytest.raises(StopIteration):
         next(generator)
-        assert False
-    except StopIteration:
-        assert True
 
 
 def test_read_input_tree_trailing_blank_lines_are_ignored():
@@ -275,14 +258,11 @@ src/
     assert next(generator) == TreeData(2, 0, True, 'src', '')
     assert next(generator) == TreeData(3, 1, False, 'data.txt', '')
     # All Remaining Lines are blank and should be ignored
-    try:
+    with pytest.raises(StopIteration):
         next(generator)
-        assert False
-    except StopIteration:
-        assert True
 
 
-def test_read_input_tree_nameless_dir_raise_exit():
+def test_read_input_tree_nameless_dir_raises_exit():
     test_input = """
 src/
   data.txt
@@ -292,11 +272,8 @@ src/
     assert next(generator) == TreeData(2, 0, True, 'src', '')
     assert next(generator) == TreeData(3, 1, False, 'data.txt', '')
     # The next line is a dir slash with no name
-    try:
+    with pytest.raises(SystemExit):
         next(generator)
-        assert False
-    except SystemExit:
-        assert True
 
 
 @pytest.mark.parametrize(
@@ -309,8 +286,5 @@ src/
 def test_read_input_tree_odd_spaces_raises_exit(test_input):
     generator = read_input_tree(test_input)
     assert next(generator) == TreeData(1, 0, True, 'src', '')
-    try:
+    with pytest.raises(SystemExit):
         next(generator)
-        assert False
-    except SystemExit:
-        assert True

--- a/test/test_string_validation.py
+++ b/test/test_string_validation.py
@@ -1,0 +1,70 @@
+""" Testing String Validation Methods.
+"""
+import pytest
+
+from treescript_files.string_validation import validate_name, validate_dir_name
+
+
+@pytest.mark.parametrize(
+    "test_input,expect",
+    [
+        (None, False),
+        (4, False),
+        ({}, False),
+        ([], False),
+        ("", False),
+        (" ", False),
+        ("\n", False),
+    ]
+)
+def test_validate_name_returns_false(test_input, expect):
+    assert validate_name(test_input) == expect
+
+
+@pytest.mark.parametrize(
+    "test_input,expect",
+    [
+        ("1", True),
+        ("a", True),
+        ("test", True),
+    ]
+)
+def test_validate_name_returns_true(test_input, expect):
+    assert validate_name(test_input) == expect
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        "1",
+        "a",
+        "test",
+    ]
+)
+def test_validate_dir_name_no_slash_chars_returns_none(test_input):
+    assert validate_dir_name(test_input) is None
+
+
+@pytest.mark.parametrize(
+    "test_input,expect",
+    [
+        ("a/", 'a'),
+        ("abc/", 'abc'),
+        ("a1/", 'a1'),
+    ]
+)
+def test_validate_dir_name_is_valid_returns_name(test_input, expect):
+    assert expect == validate_dir_name(test_input)
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        "a/b/",
+        "abc/d/",
+        "test/dir",
+    ]
+)
+def test_validate_dir_name_multi_dir_line_raises_value_error(test_input):
+    with pytest.raises(ValueError):
+        validate_dir_name(test_input)

--- a/test/test_tree_reader.py
+++ b/test/test_tree_reader.py
@@ -1,6 +1,5 @@
-"""Testing Tree Reader and Process Input Data Method
+""" Testing Tree Reader and Process Input Data Method
 """
-
 from treescript_files.input_data import InputData
 from treescript_files.tree_reader import process_input_data
 

--- a/treescript_files/__init__.py
+++ b/treescript_files/__init__.py
@@ -1,20 +1,37 @@
-"""TreeScript Files Package Methods.
+""" TreeScript Files Package Level Methods.
+ Author: DK96-OS 2024 - 2025
 """
-from treescript_files.input_data import InputData
+from treescript_files.argument_parser import parse_arguments
+from treescript_files.input_data import InputData, validate_arguments
 from treescript_files.tree_reader import process_input_data
 
 
 def ts_files(
     input_data: InputData,
 ) -> str:
-    """
-    Converts TreeScript InputData into the desired Files output.
+    """ Converts TreeScript InputData into the desired Files output.
 
-    Parameters:
-    - input_data (InputData): The program input data.
+**Parameters:**
+ - input_data (InputData): The program input data.
 
-    Returns:
-    str - The String containing all of the Files, in the desired output format.
+**Returns:**
+ str - The String containing all of the Files, in the desired output format.
     """
     file_generator = process_input_data(input_data)
     return input_data.separator.join(file_generator)
+
+
+def validate_input(
+    arguments: list[str],
+) -> InputData:
+    """ Validate the Given Arguments list using the ArgumentParser Module.
+
+**Parameters:**
+ - arguments (list[str]): The list of arguments to parse and validate.
+
+**Returns:**
+ InputData - The dataclass object containing the program input.
+    """
+    return validate_arguments(
+        parse_arguments(arguments)
+    )

--- a/treescript_files/__main__.py
+++ b/treescript_files/__main__.py
@@ -1,23 +1,25 @@
 #!/usr/bin/python
-from sys import argv, path
-
-from treescript_files import ts_files
-from treescript_files.argument_parser import parse_arguments
-from treescript_files.input_data import validate_arguments
 
 
 def main():
-    input_data = validate_arguments(
-        parse_arguments(argv[1:])
-    )
+    """ TreeScript Files Main Method (Entry Point).
+ Author: DK96-OS 2024 - 2025
+    """
+    from sys import argv
+    from treescript_files.input import validate_input
+    input_data = validate_input(argv[1:])
+    #
+    from treescript_files import ts_files
     output_data = ts_files(input_data)
+    #
     print(output_data)
 
 
 if __name__ == "__main__":
-    from pathlib import Path
     # Get the directory of the current file (__file__ is the path to the script being executed)
+    from pathlib import Path
     current_directory = Path(__file__).resolve().parent.parent
     # Add the directory to sys.path
+    from sys import path
     path.append(str(current_directory))
     main()

--- a/treescript_files/argument_data.py
+++ b/treescript_files/argument_data.py
@@ -1,25 +1,22 @@
-"""The Arguments Received from the Command Line Input.
+""" The Arguments Received from the Command Line Input.
+ - This DataClass is created after the argument syntax is validated.
 
-This DataClass is created after the argument syntax is validated.
-
-Syntax Validation:
-- The Input File is Present and non-blank.
-- The Parent Path is non-blank string or None.
+**Syntax Validation:**
+ - The Input File is Present and non-blank.
+ - The Parent Path is non-blank string or None.
 """
 from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
 class ArgumentData:
-    """
-    The syntactically valid arguments recevied by the Program.
+    """ The syntactically valid arguments received by the Program.
 
-    Fields:
-    - tree_file (str): The file containing the Tree.
-    - parent_path (str | None): The parent path to prefix files with.
-    - separator (str): The separator to use in the program output.
+**Fields:**
+ - tree_file (str): The file containing the Tree.
+ - parent_path (str?): The parent path to prefix files with.
+ - separator (str): The separator to use in the program output.
     """
-
     tree_file: str
     parent_path: str | None
     separator: str 

--- a/treescript_files/argument_parser.py
+++ b/treescript_files/argument_parser.py
@@ -4,7 +4,6 @@
 """
 from argparse import ArgumentParser
 from sys import exit
-from typing import Optional
 
 from .argument_data import ArgumentData
 from .string_validation import validate_name

--- a/treescript_files/argument_parser.py
+++ b/treescript_files/argument_parser.py
@@ -1,8 +1,6 @@
-"""Defines and Validates Argument Syntax.
-
-Encapsulates Argument Parser.
-
-Returns Argument Data, the args provided by the User.
+""" Defines and Validates Argument Syntax.
+ - Encapsulates Argument Parser.
+ - Returns Argument Data, the args provided by the User.
 """
 from argparse import ArgumentParser
 from sys import exit
@@ -12,15 +10,16 @@ from .argument_data import ArgumentData
 from .string_validation import validate_name
 
 
-def parse_arguments(args: Optional[list[str]] = None) -> ArgumentData:
-    """
-    Parse command line arguments.
+def parse_arguments(
+    args: list[str],
+) -> ArgumentData:
+    """ Parse command line arguments.
 
-    Parameters:
-    - args: A list of argument strings.
+**Parameters:**
+ - args (list[str]): A list of argument strings.
 
-    Returns:
-    ArgumentData : Container for Valid Argument Data.
+**Returns:**
+ ArgumentData - Container for Valid Argument Data.
     """
     if args is None or len(args) == 0:
         exit("No Arguments given. ")
@@ -35,14 +34,13 @@ def parse_arguments(args: Optional[list[str]] = None) -> ArgumentData:
 def _determine_output_separator(
     parsed_args,
 ) -> str:
-    """
-    Given the parsed arguments object, determine the separator.
+    """ Given the parsed arguments object, determine the separator.
 
-    Parameters:
-    - parsed_argument : The object returned by the ArgumentParser.
+**Parameters:**
+ - parsed_args (Namespace): The object returned by the ArgumentParser.
 
-    Returns:
-    str - The separator to use between elements in the output.
+**Returns:**
+ str - The separator to use between elements in the output.
     """
     if parsed_args.space:
         return ' '
@@ -56,15 +54,14 @@ def _determine_output_separator(
 def _validate_arguments(
     parsed_args,
 ) -> ArgumentData:
-    """
-    Checks the values received from the ArgParser.
-        Uses Validate Name method from StringValidation.
+    """ Checks the values received from the ArgParser.
+ - Uses Validate Name method from StringValidation.
 
-    Parameters:
-    - parsed_args : The object returned by ArgumentParser.
+**Parameters:**
+ - parsed_args : The object returned by ArgumentParser.
 
-    Returns:
-    ArgumentData - A DataClass of syntactically correct arguments.
+**Returns:**
+ ArgumentData - A DataClass of syntactically correct arguments.
     """
     tree_file = parsed_args.tree_file
     parent_path = parsed_args.parent
@@ -83,12 +80,11 @@ def _validate_arguments(
 
 
 def _define_arguments() -> ArgumentParser:
-    """
-    Initializes and Defines Argument Parser.
-       - Sets Required/Optional Arguments and Flags.
+    """ Initializes and Defines Argument Parser.
+ - Sets Required/Optional Arguments and Flags.
 
-    Returns:
-    argparse.ArgumentParser - An instance with all supported Arguments.
+**Returns:**
+ argparse.ArgumentParser - An instance with all supported Arguments.
     """
     parser = ArgumentParser(
         description="TreeScript Files",

--- a/treescript_files/file_validation.py
+++ b/treescript_files/file_validation.py
@@ -1,33 +1,34 @@
-"""File Validation Methods.
-These Methods all raise SystemExit exceptions.
+""" File Validation Methods.
+ - The Methods raise SystemExit and TypeError exceptions.
 """
-
 from pathlib import Path
 from sys import exit
 
 from .string_validation import validate_name
 
 
-def validate_input_file(file_name: str) -> str:
+def validate_input_file(
+    file_name: str,
+) -> str:
+    """ Read the Input File, Validate (non-blank) data, and return Input str.
+
+**Parameters:**
+ - file_name (str): The Name of the Input File. The Path string.
+
+**Returns:**
+ str - The String Contents of the Input File.
+
+**Raises:**
+ TypeError - If the file_name argument is not a string.
+ SystemExit - If the File does not exist, or is empty or blank, or read failed.
     """
-    Read the Input File, Validate (non-blank) data, and return Input str.
-
-    Parameters:
-    - file_name (str): The Name of the Input File.
-
-    Returns:
-    str - The String Contents of the Input File.
-
-    Raises:
-    SystemExit - If the File does not exist, or is empty or blank, or read failed.
-    """
-    file_path = Path(file_name)
-    if not file_path.exists():
+    if not isinstance(file_name, str):
+        raise TypeError
+    if not (file_path := Path(file_name)).exists():
         exit("The Input File does not Exist.")
     try:
-        data = file_path.read_text()
-    except IOError:
+        if validate_name(data := file_path.read_text()):
+            return data
+    except OSError:
         exit("Failed to Read from File.")
-    if validate_name(data):
-        return data
-    exit("Input was Empty")
+    exit("Input was Empty or Invalid.")

--- a/treescript_files/input_data.py
+++ b/treescript_files/input_data.py
@@ -1,4 +1,5 @@
-"""Valid Input Data Class.
+""" Validated Input DataClass for TreeScript Files.
+ Author: DK96-OS 2024 - 2025
 """
 from typing import Generator
 from dataclasses import dataclass
@@ -10,32 +11,37 @@ from .tree_data import TreeData
 
 @dataclass(frozen=True)
 class InputData:
-    """A Data Class Containing Program Input.
+    """ The Data Class Containing Program Input.
+ - Is utilized across packages, and thus contained within the Data package instead of the Input package where it originates from.
 
-    Fields:
-    - tree_input (str): The Tree Input to the program.
-    - parent_path (str | None): The Parent Path to prefix, or None.
-    - separator (str): The separator between elements in the program output.
+**Fields:**
+ - tree_input (str): The Tree Input to the program.
+ - parent_path (str?): The Parent Path to prefix, or None. Default: None.
+ - separator (str): The separator between elements in the program output. Default: Newline Character.
     """
-
     tree_input: str
-    parent_path: str | None
-    separator : str = '\n'
+    parent_path: str | None = None
+    separator: str = '\n'
 
     def get_tree_data(self) -> Generator[TreeData, None, None]:
-        """
-        Initializes a Generator for processing the Tree Input.
-            See line_reader module for more details.
+        """ Initializes a Generator for processing the Tree Input.
+ - See line_reader module for more details.
 
-        Returns:
-        Generator - Yields one TreeData for each Line of Tree Input.
+**Yields:**
+ TreeData - One TreeData object per Line of Tree_Input text.
         """
-        from .line_reader import read_input_tree
+        from treescript_files.line_reader import read_input_tree
         return read_input_tree(self.tree_input)
 
 
 def validate_arguments(argument_data: ArgumentData) -> InputData:
-    """Validate ArgumentData and return InputData.
+    """ Validate ArgumentData and return InputData.
+
+**Parameters:**
+ - argument_data (ArgumentData): The dataclass object containing Arguments to be validated and utilized towards producing the program InputData.
+
+**Returns:**
+ InputData - A frozen Dataclass containing validated program input.
     """
     return InputData(
         tree_input=validate_input_file(argument_data.tree_file),

--- a/treescript_files/input_data.py
+++ b/treescript_files/input_data.py
@@ -12,7 +12,6 @@ from .tree_data import TreeData
 @dataclass(frozen=True)
 class InputData:
     """ The Data Class Containing Program Input.
- - Is utilized across packages, and thus contained within the Data package instead of the Input package where it originates from.
 
 **Fields:**
  - tree_input (str): The Tree Input to the program.

--- a/treescript_files/line_reader.py
+++ b/treescript_files/line_reader.py
@@ -1,12 +1,11 @@
-"""Line Reader.
+""" Line Reader.
 
 The Default Input Reader.
-    Processes a single line at a time, and determines its key properties.
-    The Depth is the Integer number of directories between the current line and the root.
-    The Directory Boolean indicates whether the line represents a Directory.
-    The Name String is the name of the line.
+ - Processes a single line at a time, and determines its key properties.
+ - The Depth is the Integer number of directories between the current line and the root.
+ - The Directory Boolean indicates whether the line represents a Directory.
+ - The Name String is the name of the line.
 """
-
 from itertools import groupby
 from sys import exit
 from typing import Generator
@@ -18,18 +17,19 @@ from .tree_data import TreeData
 SPACE_CHARS = (" ", " ", " ", " ")
 
 
-def read_input_tree(input_tree_data: str) -> Generator[TreeData, None, None]:
-    """
-    Generate structured Tree Data from the Input Data String.
+def read_input_tree(
+    input_tree_data: str
+) -> Generator[TreeData, None, None]:
+    """ Generate TreeData objects from the TreeScript string.
 
-    Parameters:
-    - input_data (InputData): The Input.
+**Parameters:**
+ - input_tree_data (str): The Input TreeScript text string.
 
-    Returns:
-    Generator[TreeData] - Produces TreeData from the Input Data.
+**Yields:**
+ TreeData - Produces TreeData from the Input Data.
 
-    Raises:
-    SystemExit - When any Line cannot be read successfully.
+**Raises:**
+ SystemExit - When any Line cannot be read successfully.
     """
     line_number = 1
     for is_newline, group in groupby(input_tree_data, lambda x: x == "\n"):
@@ -45,19 +45,22 @@ def read_input_tree(input_tree_data: str) -> Generator[TreeData, None, None]:
             line_number += 1  # todo: Line number increase by size of group
 
 
-def _process_line(line_number: int, line: str) -> TreeData:
-    """
-    Processes a single line of the input tree structure.
-    Returns a tuple indicating the depth, type (file or directory), name of file or dir, and file data if available.
+def _process_line(
+    line_number: int,
+    line: str,
+) -> TreeData:
+    """ Processes a single line of the input tree structure.
+ - Returns a tuple indicating the depth, type (file or directory), name of file or dir, and file data if available.
 
-    Parameters:
-    - line (str): A line from the input tree structure.
+**Parameters:**
+ - line_number (int): The number for future reference.
+ - line (str): A line from the input tree structure.
 
-    Returns:
-    tuple: (int, bool, str, str) where int is the depth, bool is true when is Directory, and str is name, followed by str data.
+**Returns:**
+ TreeData - where int is the depth, bool is true when is Directory, and str is name, followed by str data.
 
-    Raises:
-    SystemExit - When Line cannot be read successfully.
+**Raises:**
+ SystemExit - When Line cannot be read successfully.
     """
     # Calculate the Depth
     depth = _calculate_depth(line)
@@ -88,41 +91,39 @@ def _process_line(line_number: int, line: str) -> TreeData:
 
 
 def _validate_node_name(node_name: str) -> tuple[bool, str] | None:
-    """
-    Determine whether this Tree Node is a Directory, and validate the name.
+    """ Determine whether this Tree Node is a Directory, and validate the name.
 
-    Parameters:
-    - node_name (str): The argument received for the node name.
+**Parameters:**
+ - node_name (str): The argument received for the node name.
 
-    Returns:
-    tuple[bool, str] - Node information, first whether it is a directory, then the valid name of the node.
+**Returns:**
+ tuple[bool, str] - Node information, first whether it is a directory, then the valid name of the node.
 
-    Raises:
-    SystemExit - When the directory name is invalid.
+**Raises:**
+ SystemExit - When the directory name is invalid.
     """
     try:
         # Check if the line contains any slash characters
         if (dir_name := validate_dir_name(node_name)) is not None:
-            return (True, dir_name)
+            return True, dir_name
         # Fall-Through to File Node
     except ValueError:
         # An error in the dir name, such that it cannot be a file either
         return None
     # Is a File
     if validate_name(node_name):
-        return (False, node_name)
+        return False, node_name
     return None
 
 
 def _calculate_depth(line: str) -> int:
-    """
-    Calculates the depth of a line in the tree structure.
+    """ Calculates the depth of a line in the tree structure.
 
-    Parameters:
-    - line (str): A line from the tree command output.
+**Parameters:**
+ - line (str): A line from the tree command output.
 
-    Returns:
-    int: The depth of the line in the tree structure, or -1 if space count is invalid.
+**Returns:**
+ int - The depth of the line in the tree structure, or -1 if space count is invalid.
     """
     from itertools import takewhile
 

--- a/treescript_files/path_stack.py
+++ b/treescript_files/path_stack.py
@@ -1,57 +1,63 @@
-"""Path Stack Management."""
+""" Path Stack Management.
+"""
 
 
 class PathStack:
-    """A Stack of Directory names in a Path."""
+    """ A Stack of Directory names in a Path.
+    
+**Method Summary:**
+ - push(str)
+ - join_stack: str
+ - reduce_depth(int): bool
+ - get_depth: int
+    """
 
     def __init__(self):
         # The Stack of Directories in the Path.
-        self._stack = []
+        self._stack: list[str] = []
 
     def push(self, directory_name: str):
-        """Push a directory to the Path Stack.
+        """ Push a directory to the Path Stack.
+        - No type or value validation is applied.
 
-        Parameters:
+        **Parameters:**
         - directory_name (str): The name of the next directory in the Path Stack.
         """
         self._stack.append(directory_name)
 
     def join_stack(self) -> str:
-        """
-        Combines all elements in the Stack to form a parent directory.
+        """ Combines all elements in the Stack to form a parent directory.
 
-        Returns:
-        str representing the current directory.
+        **Returns:**
+        str - representing the current directory.
         """
         if len(self._stack) == 0:
             return ""
         return f"{'/'.join(self._stack)}/"
 
     def reduce_depth(self, depth: int) -> bool:
-        """
-        Reduce the Depth of the Path Stack.
+        """ Reduce the Depth of the Path Stack.
+        - Modifies internal stack after validating depth argument.
 
-        Parameters:
+        **Parameters:**
         - depth (int): The depth to reduce the stack to.
 
-        Returns:
-        boolean : Whether the Reduction was successful, ie 0 or more Stack pops.
+        **Returns:**
+        boolean - Whether the Reduction was successful, ie 0 or more Stack pops.
         """
-        current_depth = self.get_depth()
+        if (current_depth := self.get_depth()) == depth:
+            return True
         if current_depth < depth or depth < 0:
             return False
-        if current_depth == depth:
-            return True
         for _ in range(current_depth, depth, -1):
             self._stack.pop()
         return True
 
     def get_depth(self) -> int:
-        """
-        Obtain the current Depth of the Stack.
-            The state where the current directory is the path, ie: './' has a depth of 0.
+        """ Obtain the current Depth of the Stack.
+        - The state where the current directory is the path, ie: './' has a depth of 0.
 
-        Returns:
-        int : The number of elements in the Path Stack.
+        **Returns:**
+        int - The number of elements in the Path Stack.
         """
         return len(self._stack)

--- a/treescript_files/string_validation.py
+++ b/treescript_files/string_validation.py
@@ -1,19 +1,18 @@
-"""String Validation Methods.
+""" String Validation Methods.
 """
 from typing import Literal
 
 
-def validate_name(argument) -> bool:
-    """
-    Determine whether an argument is a non-empty string.
-        Does not count whitespace.
-        Uses the strip method to remove empty space.
+def validate_name(argument: str) -> bool:
+    """ Determine whether an argument is a non-empty string.
+ - Does not count whitespace.
+ - Uses the strip method to remove empty space.
 
-    Parameters:
-    - argument (str) : The given argument.
+**Parameters:**
+ - argument (str): The given argument.
 
-    Returns:
-    bool - True if the argument qualifies as valid.
+**Returns:**
+ bool - True if the argument qualifies as valid.
     """
     if argument is None or not isinstance(argument, str):
         return False
@@ -23,18 +22,17 @@ def validate_name(argument) -> bool:
 
 
 def validate_dir_name(dir_name: str) -> str | None:
-    """
-    Determine that a directory is correctly formatted.
-        This method should be called once for each slash type.
+    """ Determine that a directory is correctly formatted.
+ - This method filters slash chars internally.
 
-    Parameters:
-    - dir_name (str): The given input to be validated.
+**Parameters:**
+ - dir_name (str): The given input to be validated.
 
-    Returns:
-    str | None - The valid directory name, or none if it may be a file.
+**Returns:**
+ str? - The valid directory name, or none if it may be a file.
 
-    Raises:
-    ValueError - When the name is not suitable for directories or files.
+**Raises:**
+ ValueError - When the name is not suitable for directories or files.
     """
     # Keep Name Length Reasonable
     if (name_length := len(dir_name)) >= 100:
@@ -53,18 +51,17 @@ def validate_dir_name(dir_name: str) -> str | None:
 
 
 def _validate_slash_char(dir_name: str) -> Literal['\\', '/'] | None:
-    """
-    Determine which slash char is used by the directory, if it is a directory.
-        Discourages use of both slash chars, by raising ValueError.
+    """ Determine which slash char is used by the directory, if it is a directory.
+ - Discourages use of both slash chars, by raising ValueError.
 
-    Parameters:
-    - dir_name (str): The given input to be validated.
+**Parameters:**
+ - dir_name (str): The given input to be validated.
 
-    Returns:
-    str | None - The slash character used, or none if no chars were found.
+**Returns:**
+ str? - The slash character used, or none if no chars were found.
 
-    Raises:
-    ValueError - When the name contains both slash characters.
+**Raises:**
+ ValueError - When the name contains both slash characters.
     """
     slash = None
     if '/' in dir_name:
@@ -77,23 +74,22 @@ def _validate_slash_char(dir_name: str) -> Literal['\\', '/'] | None:
 
 
 def _filter_slash_chars(dir_name: str) -> str | None:
+    """ Remove all of the slash characters and return the directory name.
+ - Returns None when there are no slash characters found.
+ - Raises ValueError when slash characters are used improperly.
+
+**Parameters:**
+ - dir_name (str): The given input to be validated.
+
+**Returns:**
+ str? - The valid directory name, or none if it may be a file.
+
+**Raises:**
+ ValueError - When the name is not suitable for directories or files.
     """
-    Remove all of the slash characters and return the directory name.
-        Returns None when there are no slash characters found.
-        Raises ValueError when slash characters are used improperly.
-
-    Parameters:
-    - dir_name (str): The given input to be validated.
-
-    Returns:
-    str | None - The valid directory name, or none if it may be a file.
-
-    Raises:
-    ValueError - When the name is not suitable for directories or files.
-    """
-    slash = _validate_slash_char(dir_name)
-    if slash is None:
+    if (slash := _validate_slash_char(dir_name)) is None:
         return None
+    slash = str(slash)
     if dir_name.endswith(slash) or dir_name.startswith(slash):
         name = dir_name.strip(slash)
         # Check for internal slash characters

--- a/treescript_files/tree_data.py
+++ b/treescript_files/tree_data.py
@@ -1,20 +1,18 @@
-"""Tree Node DataClass.
+""" Tree Node DataClass.
 """
 from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
 class TreeData:
-    """
-    A DataClass representing a Tree Node.
+    """ A DataClass representing a Tree Node.
 
-    Fields:
-    - depth (int): The depth in the tree.
-    - is_dir (bool): Whether this Node is a directory.
-    - name (str): The Name of the Tree Node.
-    - data_label (str): The Data Label.
+**Fields:**
+ - depth (int): The depth in the tree.
+ - is_dir (bool): Whether this Node is a directory.
+ - name (str): The Name of the Tree Node.
+ - data_label (str): The Data Label.
     """
-
     line_number: int
     depth: int
     is_dir: bool

--- a/treescript_files/tree_reader.py
+++ b/treescript_files/tree_reader.py
@@ -2,9 +2,9 @@
 """
 from typing import Generator
 
-from treescript_files.data.input_data import InputData
-from .path_stack import PathStack
-from .tree_data import TreeData
+from treescript_files.input_data import InputData
+from treescript_files.path_stack import PathStack
+from treescript_files.tree_data import TreeData
 
 
 def process_input_data(

--- a/treescript_files/tree_reader.py
+++ b/treescript_files/tree_reader.py
@@ -1,8 +1,8 @@
-"""Reads the TreeData from a Generator.
+""" Reads the TreeData from a Generator.
 """
 from typing import Generator
 
-from .input_data import InputData
+from treescript_files.data.input_data import InputData
 from .path_stack import PathStack
 from .tree_data import TreeData
 
@@ -12,11 +12,11 @@ def process_input_data(
 ) -> Generator[str, None, None]:
     """Process the Input Data and set-up file path generators.
 
-    Parameters:
-    - input_data (InputData): The program input data.
+**Parameters:**
+ - input_data (InputData): The program input data.
 
-    Returns:
-    Generator[str] - Yields the strings.
+**Yields:**
+ str - The file path strings.
     """
     file_generator = _process_tree_data(input_data.get_tree_data())
     if (parent := input_data.parent_path) is not None:
@@ -27,7 +27,7 @@ def process_input_data(
 def _process_tree_data(
     tree_data_generator: Generator[TreeData, None, None]
 ) -> Generator[str, None, None]:
-    """Read the TreeData to determine the File path strings.
+    """ Read the TreeData to determine the File path strings.
     """
     path_stack = PathStack()
     for tree_node in tree_data_generator:
@@ -50,7 +50,14 @@ def _prefix_parent(
     parent: str,
     input_stream: Generator[str, None, None],
 ) -> Generator[str, None, None]:
-    """Append a Prefix Parent Path to each file.
+    """ Append a Prefix Parent Path to each file.
+
+**Parameters:**
+ - parent (str): The prefix string to add to the file paths.
+ - input_stream (Generator[str]): A Generator stream of file path strings.
+
+**Yields:**
+ str - The completed File path strings.
     """
     for i in input_stream:
         yield parent + i


### PR DESCRIPTION
## Documentation
- Revise Docstrings across all Main Modules.

## Optimizations
- Remove unncessary imports (such as typing.Optional)
- Use absolute imports rather than relative
- Organize Main Module Imports

## Debug
- Additional argument type validations

## Main Package Methods
- Add a `validate_input` method to the main package init module.
- Implement `validate_input` main package method in the main method

## Workflows
- Pin External Workflow Versions (for security)
- Add missing workflow permissions blocks
- Upgrade Python versions (use 3.13 instead of 3.12 or rc)
- Set specific pytest and pytest-cov versions