### PR TITLE
Release 0.2.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,6 @@ updates:
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: "daily"
+      # Check for updates to GitHub Actions weekly
+      interval: "weekly"
     open-pull-requests-limit: 2

--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -18,7 +18,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14.0-rc.2' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/
 
       - name: Sign Distributions
-        uses: dk96-os/gh-action-sigstore-python@d83b1b22afd04932bd47c87d17f0b40fb62137cf # v3.2.8
+        uses: dk96-os/gh-action-sigstore-python@5e93f5ab8e0abc13ba45b307b8d35620b6ebd5c9 # v3.2.9
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="treescript-files",
-    version="0.2.4",
+    version="0.2.5",
     description="Obtains the relative path of all files in the TreeScript.",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Actions Workflow Upgrades

## Security Updates
- Upgrade `dk96-os/gh-action-sigstore-python` [3.2.9](https://github.com/DK96-OS/gh-action-sigstore-python/releases/tag/v3.2.9)

### Python Updates
- Add 3.14.0-rc.2 to `ci_run.yml`

## Dependabot Config
- Change Schedule Interval to Weekly